### PR TITLE
Fix the IP driver for the WattBox 800 series, and add a test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywattbox"
-version = "0.9.0"
+version = "0.9.1"
 description = "A python wrapper for WattBox APIs."
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,14 @@ optional = true
 [tool.poetry.group.dev.dependencies]
 mypy = { version = "^1.9" }
 pre-commit = { version = "*" }
+pytest = { version = "*" }
+pytest-asyncio = { version = "*" }
 ruff = { version = "*" }
 types-beautifulsoup4 = { version = "*" }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pywattbox/driver/__init__.py
+++ b/pywattbox/driver/__init__.py
@@ -20,7 +20,8 @@ WB-800-IPVM units on firmware 2.10.0.0:
 from __future__ import annotations
 
 import re
-from typing import Final, Pattern
+from re import Pattern
+from typing import Final
 
 #: Channel prompt pattern, compiled by scrapli with ``re.M | re.I``.
 #:

--- a/pywattbox/driver/__init__.py
+++ b/pywattbox/driver/__init__.py
@@ -1,10 +1,100 @@
-from typing import Final
+"""Shared protocol helpers for the WattBox IP (telnet/SSH) drivers.
 
+The WattBox "Integration Protocol" is line oriented. Every message is a single
+line terminated by ``\\n``:
+
+* ``?Key=value``  -- reply to a ``?`` request message
+* ``OK``          -- reply to a ``!`` control message
+* ``#Error``      -- the request was rejected or is unsupported
+
+Two properties of real hardware shape everything below, both confirmed against
+WB-800-IPVM units on firmware 2.10.0.0:
+
+* **Values may contain spaces, commas, braces and parentheses.** Outlet names
+  are user supplied, e.g. ``?OutletName={Media Bridge 1 to 3},{Free}``.
+* **Commands are not echoed over raw telnet.** They are echoed over SSH. Any
+  parsing that assumes a fixed line index therefore breaks on one transport or
+  the other.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Pattern
+
+#: Channel prompt pattern, compiled by scrapli with ``re.M | re.I``.
+#:
+#: Used by ``_read_until_prompt`` during login. Note that scrapli's
+#: ``_process_read_buf`` partitions the buffer on ``\n`` and searches what
+#: remains, so the trailing newline is *not* visible to this pattern -- a
+#: pattern requiring ``\n`` can never match, which is why the old ``#Error``
+#: branch never fired. Each alternative is wrapped in a non-capturing group so
+#: that ``^`` and ``$`` anchor all of them; without the group, alternation
+#: binds looser than the anchors and every branch except the first and last
+#: floats free, matching mid-line.
 PROMPTS: Final[str] = (
-    r"^"  # Start of the string
-    r"(.*Successfully Logged In!)|"  # After Login
-    r"(\?\w+=\S+)|"  # Response to `?` request message
-    r"(OK)|"  # Response to `!` control message
-    r"(#Error)"  # Error Message
-    r"\n$"  # Newline / End of String
+    r"^(?:"
+    r"(?:.*Successfully Logged In!)"  # After login
+    r"|(?:\?\w+(?:=[^\r\n]*)?)"  # Response to a `?` request message
+    r"|(?:OK)"  # Response to a `!` control message
+    r"|(?:#Error)"  # Error message
+    r")[ \t]*\r?$"
 )
+
+#: Transport names that speak plain telnet rather than SSH. Compare against
+#: ``driver.transport_name``; ``driver.transport`` is a transport *object* and
+#: will never equal any of these strings.
+TELNET_TRANSPORTS: Final[tuple[str, ...]] = ("telnet", "asynctelnet")
+
+#: Login prompts presented in-channel by the 800 series.
+USERNAME_PROMPT: Final[bytes] = b"Username:"
+PASSWORD_PROMPT: Final[bytes] = b"Password:"
+LOGIN_SUCCESS: Final[bytes] = b"Successfully Logged In"
+
+ERROR_MESSAGE: Final[str] = "#Error"
+
+
+def _reply_body(command: str) -> bytes:
+    """Regex body matching a valid reply line for *command*."""
+    if command.startswith("?"):
+        # `?OutletPowerStatus=1` requests carry an argument; the reply repeats
+        # the key, so match on the key alone.
+        key = re.escape(command.split("=", 1)[0].encode())
+        return rb"(?:" + key + rb"=(?P<value>[^\r\n]*)|(?P<error>#Error))"
+    return rb"(?:(?P<value>OK)|(?P<error>#Error))"
+
+
+def reply_patterns(command: str) -> tuple[Pattern[bytes], Pattern[bytes]]:
+    """Return ``(strict, lenient)`` patterns matching a reply to *command*.
+
+    The strict pattern requires the terminating newline, which is what makes
+    incremental reads safe: without it a reply still arriving in pieces --
+    ``?OutletName={Media Brid`` -- looks like a complete line and would be
+    accepted truncated.
+
+    The lenient pattern drops that requirement and is used only as a fallback
+    once reading has stopped, for a device that closes without a final newline.
+    """
+    body = _reply_body(command)
+    strict = re.compile(rb"(?m)^" + body + rb"[ \t]*\r?\n")
+    lenient = re.compile(rb"(?m)^" + body + rb"[ \t]*\r?$")
+    return strict, lenient
+
+
+def find_reply(buffer: bytes, command: str, *, strict: bool = True) -> bytes | None:
+    """Extract the reply value for *command* from *buffer*, or ``None``.
+
+    Skips a line that is merely the echoed command. This matters for requests
+    carrying an argument: the echo of ``?OutletPowerStatus=1`` is itself a
+    syntactically valid ``key=value`` line, so taking the first match would
+    return the echo instead of the reading.
+    """
+    pattern = reply_patterns(command)[0 if strict else 1]
+    encoded = command.encode()
+    for match in pattern.finditer(buffer):
+        if match.group(0).strip() == encoded:
+            continue  # echoed command, not the reply
+        if match.group("error") is not None:
+            return ERROR_MESSAGE.encode()
+        return match.group("value")
+    return None

--- a/pywattbox/driver/async_driver.py
+++ b/pywattbox/driver/async_driver.py
@@ -7,18 +7,63 @@ from typing import Any
 
 from scrapli.decorators import timeout_modifier
 from scrapli.driver import AsyncDriver
-from scrapli.exceptions import ScrapliConnectionNotOpened
+from scrapli.exceptions import ScrapliConnectionNotOpened, ScrapliTimeout
 from scrapli.response import Response
 
-from . import PROMPTS
+from . import (
+    LOGIN_SUCCESS,
+    PASSWORD_PROMPT,
+    PROMPTS,
+    TELNET_TRANSPORTS,
+    USERNAME_PROMPT,
+    find_reply,
+)
 
 logger = logging.getLogger("pywattbox.async_driver")
 
 
+async def _read_until_token(driver: WattBoxAsyncDriver, token: bytes) -> bytes:
+    """Accumulate channel reads until *token* appears.
+
+    Raises:
+        ScrapliTimeout: if the transport stops producing data first.
+    """
+    buf = b""
+    while token not in buf:
+        chunk = await driver.channel.read()
+        if not chunk:
+            raise ScrapliTimeout(
+                f"connection closed while waiting for {token!r}, got {buf!r}"
+            )
+        buf += chunk
+    return buf
+
+
 async def on_open(driver: WattBoxAsyncDriver) -> None:
-    # if driver.transport_name not in ("telnet", "asynctelnet"):
+    """Complete the login handshake.
+
+    Over SSH the transport authenticates and we only need to consume the
+    banner. Over telnet the device presents its own ``Username:``/``Password:``
+    prompts, which scrapli's in-channel telnet auth does not satisfy (it is
+    rejected as ``Invalid Login``), so authentication is bypassed at the
+    transport level -- see ``WattBoxAsyncDriver.__init__`` -- and performed
+    here instead.
+    """
     logger.debug("On Open")
-    await driver.channel._read_until_prompt()
+    if driver.transport_name not in TELNET_TRANSPORTS:
+        await driver.channel._read_until_prompt()
+        return
+
+    await _read_until_token(driver, USERNAME_PROMPT)
+    driver.channel.write(driver.auth_username)
+    driver.channel.send_return()
+
+    await _read_until_token(driver, PASSWORD_PROMPT)
+    driver.channel.write(driver.auth_password)
+    driver.channel.send_return()
+
+    await _read_until_token(driver, LOGIN_SUCCESS)
+    logger.debug("Telnet login complete")
 
 
 async def on_close(driver: WattBoxAsyncDriver) -> None:
@@ -57,6 +102,11 @@ class WattBoxAsyncDriver(AsyncDriver):
         channel_lock: bool = True,
         logging_uid: str = "",
     ) -> None:
+        if transport in TELNET_TRANSPORTS:
+            # scrapli's in-channel telnet auth does not satisfy the WattBox
+            # login prompt; `on_open` performs the handshake by hand instead.
+            auth_bypass = True
+
         super().__init__(
             host=host,
             port=port,
@@ -93,18 +143,26 @@ class WattBoxAsyncDriver(AsyncDriver):
         self,
         command: str,
     ) -> Response:
-        """Send a command.
+        """Send one request and return its single-line reply.
 
-        Based on:
-            scrapli.driver.generic.async_driver.GenericDriver: send_command and _send_command
-            scrapli.channel.async_channel.Channel: send_input
+        Reads until a *complete* reply line for this command arrives, rather
+        than relying on scrapli's prompt matching. Three properties of the
+        WattBox protocol make prompt matching unsuitable here:
+
+        * replies carry no trailing prompt, so there is nothing to anchor on
+        * values contain spaces and commas, so a whitespace-delimited pattern
+          truncates them
+        * the reply is not echoed over telnet, so its position in the buffer
+          is transport dependent
 
         Args:
-            command: string to send to device in privilege exec mode
-            failed_when_contains: string or list of strings indicating failure if found in response
+            command: request (``?``) or control (``!``) message to send
 
         Returns:
-            Response: Scrapli Response object
+            Response: scrapli Response whose ``result`` is the reply value
+
+        Raises:
+            ScrapliTimeout: if the device sends no usable reply
         """
         await self._open()
 
@@ -116,42 +174,38 @@ class WattBoxAsyncDriver(AsyncDriver):
 
         logger.debug("Sending Command: %s", command)
 
-        # Normally handled in the channel `send_input`, but WattBox is special and doesn't work
-        # with that function. Pulled it all into the Driver for simplicity.
+        # Normally handled by the channel's `send_input`, but this protocol has
+        # no prompt for scrapli to synchronise on, so the exchange is driven
+        # here instead.
+        raw_response = b""
         async with self.channel._channel_lock():
             self.channel.write(command)
             self.channel.send_return()
-            raw_response = await self.channel._read_until_prompt()
 
-            logger.debug("raw_response: %s", raw_response)
-            split_response = raw_response.strip().splitlines()
-            logger.debug("split_response: %s", split_response)
-            if (
-                self.transport not in ("telnet", "asynctelnet")
-                and len(split_response) < 2
-            ):
-                logger.debug("Not enough lines: %s. Getting more", len(split_response))
-                raw_response += await self.channel._read_until_prompt()
-                logger.debug("raw_response: %s", raw_response)
-                split_response = raw_response.strip().splitlines()
-                logger.debug("split_response: %s", split_response)
+            while True:
+                try:
+                    chunk = await self.channel.read()
+                except ScrapliTimeout:
+                    logger.debug("Read timed out for %s", command)
+                    break
+                if not chunk:
+                    logger.debug("Connection closed while reading %s", command)
+                    break
+                raw_response += chunk
+                if find_reply(raw_response, command) is not None:
+                    break
 
-        if (
-            self.transport not in ("telnet", "asynctelnet")
-            and split_response[0] != command.encode()
-        ):
-            logger.error("Doesn't match command: %s - %s", command, split_response[0])
-
-        if command.startswith("?"):
-            if not split_response[-1].startswith(command.encode()):
-                logger.error(
-                    "Expected response to start with: %s, Got %s",
-                    command,
-                    split_response[-1],
-                )
-            processed_response = split_response[1].split(b"=")[-1]
-        else:
-            processed_response = split_response[-1]
+        logger.debug("raw_response: %s", raw_response)
+        # Fall back to a newline-less match only after reading has stopped, for
+        # a device that closes the connection without terminating the line.
+        processed_response = find_reply(raw_response, command)
+        if processed_response is None:
+            processed_response = find_reply(raw_response, command, strict=False)
+        if processed_response is None:
+            raise ScrapliTimeout(
+                f"no reply to {command!r} from {self._base_transport_args.host}; "
+                f"read {raw_response!r}"
+            )
 
         logger.debug("processed_response: %s", processed_response)
         response.record_response(processed_response)

--- a/pywattbox/driver/sync_driver.py
+++ b/pywattbox/driver/sync_driver.py
@@ -7,17 +7,55 @@ from typing import Any
 
 from scrapli.decorators import timeout_modifier
 from scrapli.driver import Driver
-from scrapli.exceptions import ScrapliConnectionNotOpened
+from scrapli.exceptions import ScrapliConnectionNotOpened, ScrapliTimeout
 from scrapli.response import Response
 
-from . import PROMPTS
+from . import (
+    LOGIN_SUCCESS,
+    PASSWORD_PROMPT,
+    PROMPTS,
+    TELNET_TRANSPORTS,
+    USERNAME_PROMPT,
+    find_reply,
+)
 
 logger = logging.getLogger("pywattbox.sync_driver")
 
 
+def _read_until_token(driver: WattBoxDriver, token: bytes) -> bytes:
+    """Accumulate channel reads until *token* appears.
+
+    Raises:
+        ScrapliTimeout: if the transport stops producing data first.
+    """
+    buf = b""
+    while token not in buf:
+        chunk = driver.channel.read()
+        if not chunk:
+            raise ScrapliTimeout(
+                f"connection closed while waiting for {token!r}, got {buf!r}"
+            )
+        buf += chunk
+    return buf
+
+
 def on_open(driver: WattBoxDriver) -> None:
-    if driver.transport_name not in ("telnet", "asynctelnet"):
+    """Complete the login handshake. Mirrors the async driver's ``on_open``."""
+    logger.debug("On Open")
+    if driver.transport_name not in TELNET_TRANSPORTS:
         driver.channel._read_until_prompt()
+        return
+
+    _read_until_token(driver, USERNAME_PROMPT)
+    driver.channel.write(driver.auth_username)
+    driver.channel.send_return()
+
+    _read_until_token(driver, PASSWORD_PROMPT)
+    driver.channel.write(driver.auth_password)
+    driver.channel.send_return()
+
+    _read_until_token(driver, LOGIN_SUCCESS)
+    logger.debug("Telnet login complete")
 
 
 def on_close(driver: WattBoxDriver) -> None:
@@ -56,6 +94,11 @@ class WattBoxDriver(Driver):
         channel_lock: bool = True,
         logging_uid: str = "",
     ) -> None:
+        if transport in TELNET_TRANSPORTS:
+            # scrapli's in-channel telnet auth does not satisfy the WattBox
+            # login prompt; `on_open` performs the handshake by hand instead.
+            auth_bypass = True
+
         super().__init__(
             host=host,
             port=port,
@@ -92,18 +135,19 @@ class WattBoxDriver(Driver):
         self,
         command: str,
     ) -> Response:
-        """Send a command.
+        """Send one request and return its single-line reply.
 
-        Based on:
-            scrapli.driver.generic.sync_driver.GenericDriver: send_command and _send_command
-            scrapli.channel.sync_channel.Channel: send_input
+        Synchronous mirror of ``WattBoxAsyncDriver._send_command``; see that
+        method for why scrapli's prompt matching is not usable here.
 
         Args:
-            command: string to send to device in privilege exec mode
-            failed_when_contains: string or list of strings indicating failure if found in response
+            command: request (``?``) or control (``!``) message to send
 
         Returns:
-            Response: Scrapli Response object
+            Response: scrapli Response whose ``result`` is the reply value
+
+        Raises:
+            ScrapliTimeout: if the device sends no usable reply
         """
         self._open()
 
@@ -113,42 +157,35 @@ class WattBoxDriver(Driver):
             failed_when_contains="#Error",
         )
 
-        # Normally handled in the channel `send_input`, but WattBox is special and doesn't work
-        # with that function. Pulled it all into the Driver for simplicity.
+        logger.debug("Sending Command: %s", command)
+
+        raw_response = b""
         with self.channel._channel_lock():
             self.channel.write(command)
             self.channel.send_return()
-            raw_response = self.channel._read_until_prompt()
 
-            logger.debug("raw_response: %s", raw_response)
-            split_response = raw_response.strip().splitlines()
-            logger.debug("split_response: %s", split_response)
-            if (
-                self.transport not in ("telnet", "asynctelnet")
-                and len(split_response) < 2
-            ):
-                logger.error("Not enough lines: %s. Getting more", len(split_response))
-                raw_response += self.channel._read_until_prompt()
-                logger.debug("raw_response: %s", raw_response)
-                split_response = raw_response.strip().splitlines()
-                logger.debug("split_response: %s", split_response)
+            while True:
+                try:
+                    chunk = self.channel.read()
+                except ScrapliTimeout:
+                    logger.debug("Read timed out for %s", command)
+                    break
+                if not chunk:
+                    logger.debug("Connection closed while reading %s", command)
+                    break
+                raw_response += chunk
+                if find_reply(raw_response, command) is not None:
+                    break
 
-        if (
-            self.transport not in ("telnet", "asynctelnet")
-            and split_response[0] != command.encode()
-        ):
-            logger.error("Doesn't match command: %s - %s", command, split_response[0])
-
-        if command.startswith("?"):
-            if not split_response[-1].startswith(command.encode()):
-                logger.error(
-                    "Expected response to start with: %s, Got %s",
-                    command,
-                    split_response[-1],
-                )
-            processed_response = split_response[1].split(b"=")[-1]
-        else:
-            processed_response = split_response[-1]
+        logger.debug("raw_response: %s", raw_response)
+        processed_response = find_reply(raw_response, command)
+        if processed_response is None:
+            processed_response = find_reply(raw_response, command, strict=False)
+        if processed_response is None:
+            raise ScrapliTimeout(
+                f"no reply to {command!r} from {self._base_transport_args.host}; "
+                f"read {raw_response!r}"
+            )
 
         logger.debug("processed_response: %s", processed_response)
         response.record_response(processed_response)

--- a/pywattbox/ip_wattbox.py
+++ b/pywattbox/ip_wattbox.py
@@ -254,12 +254,13 @@ class IpWattBox(BaseWattBox):
 
     @property
     def update_requests(self) -> tuple[REQUEST_MESSAGES | str, ...]:
-        # UPS status is only requested when a UPS is actually attached. Asking
-        # a unit without one wastes a round trip and yields a reply that
-        # `parse_ups_status` cannot parse.
+        # UPS status is requested unconditionally. A unit with no UPS still
+        # answers with a well-formed tuple (`0,0,Good,False,0,False,False` on
+        # WB-800-IPVM-6 / fw 2.10.0.0), and `power_lost` from that reply backs
+        # a binary sensor that must keep reporting on such units.
         return (
             *UPDATE_BASE_REQUESTS,
-            *((REQUEST_MESSAGES.UPS_STATUS,) if self.has_ups else ()),
+            REQUEST_MESSAGES.UPS_STATUS,
             *(
                 (
                     REQUEST_MESSAGES.OUTLET_POWER_STATUS.value.format(
@@ -273,16 +274,14 @@ class IpWattBox(BaseWattBox):
         )
 
     def _parse_update(self, responses: list[Response]) -> None:
-        """Dispatch update responses, honouring the optional request blocks.
+        """Dispatch update responses in the order `update_requests` built them.
 
-        The response list mirrors `update_requests`, so the offsets have to be
-        derived from the same flags rather than hard coded.
+        Shared by `update` and `async_update` so the two cannot drift apart.
         """
         offset = len(UPDATE_BASE_REQUESTS)
         self.parse_update_base(UpdateBaseResponses(*responses[:offset]))
-        if self.has_ups:
-            self.parse_ups_status(responses[offset])
-            offset += 1
+        self.parse_ups_status(responses[offset])
+        offset += 1
         if self.outlet_power_status:
             self.parse_outlet_power_statuses(responses[offset:])
 

--- a/pywattbox/ip_wattbox.py
+++ b/pywattbox/ip_wattbox.py
@@ -315,6 +315,24 @@ class IpWattBox(BaseWattBox):
         )
         await self.async_update()
 
+    def close(self) -> None:
+        """Close the connection, releasing the session on the device.
+
+        The 800 series caps concurrent sessions, so a consumer that
+        re-creates its WattBox -- a Home Assistant config entry reload, for
+        instance -- eventually locks itself out unless the old connection is
+        closed. Safe to call when never opened or already closed.
+        """
+        if self._driver is not None and self._driver.transport.isalive():
+            logger.debug("Closing driver")
+            self._driver.close()
+
+    async def async_close(self) -> None:
+        """Async counterpart to `close`."""
+        if self._async_driver is not None and self._async_driver.transport.isalive():
+            logger.debug("Closing async driver")
+            await self._async_driver.close()
+
     # String Representation
     def __str__(self) -> str:
         return f"{self.hostname} ({self.host}): {self.hardware_version}"

--- a/pywattbox/ip_wattbox.py
+++ b/pywattbox/ip_wattbox.py
@@ -254,9 +254,12 @@ class IpWattBox(BaseWattBox):
 
     @property
     def update_requests(self) -> tuple[REQUEST_MESSAGES | str, ...]:
+        # UPS status is only requested when a UPS is actually attached. Asking
+        # a unit without one wastes a round trip and yields a reply that
+        # `parse_ups_status` cannot parse.
         return (
             *UPDATE_BASE_REQUESTS,
-            REQUEST_MESSAGES.UPS_STATUS,
+            *((REQUEST_MESSAGES.UPS_STATUS,) if self.has_ups else ()),
             *(
                 (
                     REQUEST_MESSAGES.OUTLET_POWER_STATUS.value.format(
@@ -269,21 +272,27 @@ class IpWattBox(BaseWattBox):
             ),
         )
 
+    def _parse_update(self, responses: list[Response]) -> None:
+        """Dispatch update responses, honouring the optional request blocks.
+
+        The response list mirrors `update_requests`, so the offsets have to be
+        derived from the same flags rather than hard coded.
+        """
+        offset = len(UPDATE_BASE_REQUESTS)
+        self.parse_update_base(UpdateBaseResponses(*responses[:offset]))
+        if self.has_ups:
+            self.parse_ups_status(responses[offset])
+            offset += 1
+        if self.outlet_power_status:
+            self.parse_outlet_power_statuses(responses[offset:])
+
     def update(self) -> None:
         logger.debug("Update")
-        responses = self.send_requests(self.update_requests)
-        self.parse_update_base(UpdateBaseResponses(*responses[0:4]))
-        self.parse_ups_status(responses[4])
-        if self.outlet_power_status:
-            self.parse_outlet_power_statuses(responses[5:])
+        self._parse_update(self.send_requests(self.update_requests))
 
     async def async_update(self) -> None:
         logger.debug("Async Update")
-        responses = await self.async_send_requests(self.update_requests)
-        self.parse_update_base(UpdateBaseResponses(*responses[0:4]))
-        self.parse_ups_status(responses[4])
-        if self.outlet_power_status:
-            self.parse_outlet_power_statuses(responses[5:])
+        self._parse_update(await self.async_send_requests(self.update_requests))
 
     def send_command(self, outlet: int, command: Commands) -> None:
         logger.debug("Send Command")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ firmware 2.10.0.0 -- see tests/fixtures.py.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from io import SEEK_END, BytesIO
-from typing import Callable
 
 import pytest
 from scrapli.channel.base_channel import BaseChannel, BaseChannelArgs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,149 @@
+"""Test fixtures for the WattBox IP driver.
+
+The fake channel below mirrors the parts of ``scrapli.channel.AsyncChannel``
+that the driver actually uses, and deliberately reuses scrapli's *real* prompt
+matching helpers (``_get_prompt_pattern`` and ``_process_read_buf``). That
+matters: the driver's bugs live in how its prompt pattern interacts with those
+helpers, so a hand-rolled approximation would hide them.
+
+Device behaviour is scripted from wire captures of real WB-800-IPVM units on
+firmware 2.10.0.0 -- see tests/fixtures.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from io import SEEK_END, BytesIO
+from typing import Callable
+
+import pytest
+from scrapli.channel.base_channel import BaseChannel, BaseChannelArgs
+from scrapli.exceptions import ScrapliTimeout
+
+
+class FakeDevice:
+    """Scripted WattBox.
+
+    Args:
+        replies: maps a command string to the bytes the device emits in
+            response. A command absent from the mapping produces no reply at
+            all, which is how these units answer some unsupported requests.
+        echo: whether the device echoes the command back before replying.
+            The 800s do not echo over raw telnet; they do over SSH.
+        chunk_size: if set, split each reply into chunks of this size to
+            simulate a response arriving across several packets.
+    """
+
+    def __init__(
+        self,
+        replies: dict[str, bytes],
+        *,
+        echo: bool = False,
+        chunk_size: int | None = None,
+    ) -> None:
+        self.replies = replies
+        self.echo = echo
+        self.chunk_size = chunk_size
+        self.received: list[str] = []
+
+    def feed(self, command: str) -> list[bytes]:
+        """Return the chunks the device would put on the wire for *command*."""
+        self.received.append(command)
+        out = b""
+        if self.echo:
+            out += command.encode() + b"\r\n"
+        out += self.replies.get(command, b"")
+        if not out:
+            return []
+        if self.chunk_size:
+            return [
+                out[i : i + self.chunk_size]
+                for i in range(0, len(out), self.chunk_size)
+            ]
+        return [out]
+
+
+class FakeChannel:
+    """Stand-in for scrapli's AsyncChannel, backed by a FakeDevice."""
+
+    def __init__(self, device: FakeDevice, comms_prompt_pattern: str) -> None:
+        self.device = device
+        self._pending: list[bytes] = []
+        self._partial_command = ""
+        self._channel_args = BaseChannelArgs(comms_prompt_pattern=comms_prompt_pattern)
+        # BaseChannel._process_read_buf only touches _base_channel_args, so a
+        # minimal stand-in is enough to borrow the real implementation.
+        self._search_depth = self._channel_args.comms_prompt_search_depth
+
+    # -- scrapli Channel surface used by the driver -------------------------
+    @asynccontextmanager
+    async def _channel_lock(self):
+        yield
+
+    def write(self, channel_input: str, **_kwargs) -> None:
+        self._partial_command += channel_input
+
+    def send_return(self) -> None:
+        command, self._partial_command = self._partial_command, ""
+        self._pending.extend(self.device.feed(command))
+
+    async def read(self) -> bytes:
+        """Return the next chunk, or time out if the device has gone quiet.
+
+        A real transport blocks here until data arrives or the transport
+        timeout fires; raising ScrapliTimeout is the faithful equivalent and
+        keeps a hung driver from hanging the test suite.
+        """
+        if not self._pending:
+            raise ScrapliTimeout("no more data from device")
+        await asyncio.sleep(0)
+        return self._pending.pop(0)
+
+    async def _read_until_prompt(self, buf: bytes = b"") -> bytes:
+        """Faithful copy of scrapli's AsyncChannel._read_until_prompt."""
+        search_pattern = BaseChannel._get_prompt_pattern(
+            class_pattern=self._channel_args.comms_prompt_pattern
+        )
+        read_buf = BytesIO(buf)
+        while True:
+            read_buf.write(await self.read())
+            search_buf = self._process_read_buf(read_buf)
+            if search_pattern.search(search_buf):
+                return read_buf.getvalue()
+
+    def _process_read_buf(self, read_buf: BytesIO) -> bytes:
+        """Faithful copy of scrapli's BaseChannel._process_read_buf."""
+        read_buf.seek(-self._search_depth, SEEK_END)
+        search_buf = read_buf.read()
+        before, _, search_buf = search_buf.partition(b"\n")
+        if not search_buf:
+            search_buf = before
+        return search_buf
+
+
+@pytest.fixture
+def make_driver() -> Callable:
+    """Build a WattBoxAsyncDriver wired to a FakeDevice, with no real socket."""
+    from pywattbox.driver.async_driver import WattBoxAsyncDriver
+
+    def _make(device: FakeDevice, transport: str = "asynctelnet") -> WattBoxAsyncDriver:
+        driver = WattBoxAsyncDriver(
+            host="192.0.2.1",
+            port=23 if transport == "asynctelnet" else 22,
+            auth_username="admin",
+            auth_password="secret",
+            transport=transport,
+        )
+        driver._fake_channel = FakeChannel(  # type: ignore[attr-defined]
+            device, driver.channel._base_channel_args.comms_prompt_pattern
+        )
+        driver.channel = driver._fake_channel  # type: ignore[assignment]
+
+        async def _noop_open(force: bool = False) -> None:
+            return None
+
+        driver._open = _noop_open  # type: ignore[assignment]
+        return driver
+
+    return _make

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,11 @@
 """Wire-level fixtures for WB-800-IPVM-6, firmware 2.10.0.0.
 
 Transcribed from a live capture of a deployed unit (dropbear_2025.88 SSH
-server, telnet API on port 23). Serial number and outlet names are altered;
-every response *shape* is verbatim.
+server, telnet API on port 23). Response *shapes*, field counts, numeric
+formats and framing are verbatim. The service tag and outlet names are
+substitutes chosen to preserve the properties under test -- embedded spaces,
+digits, varying lengths and repeated values -- without identifying a real
+site.
 
 What the capture established, some of it contrary to
 eseglem/hass-wattbox#55:
@@ -25,8 +28,8 @@ eseglem/hass-wattbox#55:
 
 from __future__ import annotations
 
-# Names as captured: spaces and digits, brace wrapped, comma separated. A
-# parser that reads only up to the first whitespace truncates these.
+# Brace wrapped, comma separated, with embedded spaces and digits. A parser
+# that reads only up to the first whitespace truncates these.
 OUTLET_NAMES = (
     "Media Bridge 1 to 3",
     "Streaming Box 06 Study",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,66 @@
+"""Wire-level fixtures for WB-800-IPVM units, firmware 2.10.0.0.
+
+Response shapes are taken from the captures in eseglem/hass-wattbox#55 (real
+WB-800-IPVM-12 and WB-820-IPVM-12) and adapted to a 6-outlet WB-800-IPVM-6.
+
+Two properties of this protocol drive most of the driver's bugs, so the outlet
+names here are deliberately realistic rather than tidy:
+
+* values may contain spaces, parentheses and braces (``?OutletName``)
+* every reply is a single ``?Key=value`` line terminated by ``\\n``, with no
+  trailing CLI prompt and no command echo over raw telnet
+"""
+
+from __future__ import annotations
+
+# Outlet names as they actually appear on a deployed unit: spaces, digits,
+# parentheses. A driver that reads only up to the first whitespace truncates
+# these, which is exactly the failure mode being guarded against.
+OUTLET_NAMES = (
+    "Media Bridge 1 to 3",
+    "Display 07 Study",
+    "Free",
+    "HDMI Adapter Main Lounge",
+    "Media Bridge 1 to 3",
+    "Free",
+)
+
+WB800_IPVM_6: dict[str, bytes] = {
+    "?Model": b"?Model=WB-800-IPVM-6\n",
+    "?Firmware": b"?Firmware=2.10.0.0\n",
+    "?ServiceTag": b"?ServiceTag=ST000000000000\n",
+    "?Hostname": b"?Hostname=WattBox\n",
+    "?OutletCount": b"?OutletCount=6\n",
+    "?OutletName": (
+        "?OutletName=" + ",".join("{" + n + "}" for n in OUTLET_NAMES) + "\n"
+    ).encode(),
+    "?OutletStatus": b"?OutletStatus=1,1,1,1,1,0\n",
+    "?PowerStatus": b"?PowerStatus=0.4,48.0,120.0,0\n",
+    "?AutoReboot": b"?AutoReboot=1\n",
+    "?UPSConnection": b"?UPSConnection=0\n",
+    "?OutletPowerStatus=1": b"?OutletPowerStatus=1,17.9,0.1,120.0\n",
+    "?OutletPowerStatus=2": b"?OutletPowerStatus=2,21.4,0.2,120.0\n",
+    "?OutletPowerStatus=3": b"?OutletPowerStatus=3,0.0,0.0,120.0\n",
+    "?OutletPowerStatus=4": b"?OutletPowerStatus=4,4.2,0.0,120.0\n",
+    "?OutletPowerStatus=5": b"?OutletPowerStatus=5,4.5,0.0,120.0\n",
+    "?OutletPowerStatus=6": b"?OutletPowerStatus=6,0.0,0.0,120.0\n",
+    # PROVISIONAL: the exact reply a unit with no UPS gives to ?UPSStatus has
+    # not yet been captured from hardware -- `#Error` is the assumption being
+    # tested, and this fixture must be reconciled against captures/ before the
+    # upstream PR cites it. The driver is written so that either answer is
+    # handled: `update_requests` skips ?UPSStatus entirely unless
+    # ?UPSConnection reported a UPS, so this line only exercises the
+    # error-reply path of the driver itself.
+    "?UPSStatus": b"#Error\n",
+}
+
+# Control messages answer with a bare OK. Included so the driver's non-"?"
+# path is covered; the tests never send these to real hardware.
+CONTROL_OK: dict[str, bytes] = {
+    "!OutletSet=1,ON,0": b"OK\n",
+    "!OutletSet=1,OFF,0": b"OK\n",
+}
+
+LOGIN_BANNER = b"\r\nUsername: "
+LOGIN_PASSWORD_PROMPT = b"\r\nPassword: "
+LOGIN_SUCCESS = b"\r\nSuccessfully Logged In!\r\n"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,27 +1,38 @@
-"""Wire-level fixtures for WB-800-IPVM units, firmware 2.10.0.0.
+"""Wire-level fixtures for WB-800-IPVM-6, firmware 2.10.0.0.
 
-Response shapes are taken from the captures in eseglem/hass-wattbox#55 (real
-WB-800-IPVM-12 and WB-820-IPVM-12) and adapted to a 6-outlet WB-800-IPVM-6.
+Transcribed from a live capture of a deployed unit (dropbear_2025.88 SSH
+server, telnet API on port 23). Serial number and outlet names are altered;
+every response *shape* is verbatim.
 
-Two properties of this protocol drive most of the driver's bugs, so the outlet
-names here are deliberately realistic rather than tidy:
+What the capture established, some of it contrary to
+eseglem/hass-wattbox#55:
 
-* values may contain spaces, parentheses and braces (``?OutletName``)
-* every reply is a single ``?Key=value`` line terminated by ``\\n``, with no
-  trailing CLI prompt and no command echo over raw telnet
+* **No echo over telnet.** Each request produces exactly one line: the reply.
+  Nothing else is sent.
+* **Login is LF-framed, not CRLF**, and arrives as
+  ``Please Login to Continue\\n`` then ``Username: `` then ``Password: `` then
+  ``Successfully Logged In!\\n``. There is no telnet IAC option negotiation at
+  all -- it is a raw line protocol.
+* **Values contain spaces.** ``?OutletName`` returns brace-wrapped names such
+  as ``{Media Bridge 1 to 3}``.
+* **A unit with no UPS still answers ``?UPSStatus`` with a valid tuple**, not
+  an error. ``?UPSConnection=0`` and ``?UPSStatus=0,0,Good,False,0,False,False``
+  coexist happily.
+* **No request in the read-only set produced ``#Error``.** The error path is
+  still handled by the driver because the protocol documents it, but it is not
+  exercised by this hardware and is covered separately below.
 """
 
 from __future__ import annotations
 
-# Outlet names as they actually appear on a deployed unit: spaces, digits,
-# parentheses. A driver that reads only up to the first whitespace truncates
-# these, which is exactly the failure mode being guarded against.
+# Names as captured: spaces and digits, brace wrapped, comma separated. A
+# parser that reads only up to the first whitespace truncates these.
 OUTLET_NAMES = (
     "Media Bridge 1 to 3",
+    "Streaming Box 06 Study",
+    "HDMI Adapter Main Lounge",
     "Display 07 Study",
     "Free",
-    "HDMI Adapter Main Lounge",
-    "Media Bridge 1 to 3",
     "Free",
 )
 
@@ -29,38 +40,42 @@ WB800_IPVM_6: dict[str, bytes] = {
     "?Model": b"?Model=WB-800-IPVM-6\n",
     "?Firmware": b"?Firmware=2.10.0.0\n",
     "?ServiceTag": b"?ServiceTag=ST000000000000\n",
+    # The 800s report a generic hostname unless one has been configured.
     "?Hostname": b"?Hostname=WattBox\n",
     "?OutletCount": b"?OutletCount=6\n",
     "?OutletName": (
         "?OutletName=" + ",".join("{" + n + "}" for n in OUTLET_NAMES) + "\n"
     ).encode(),
-    "?OutletStatus": b"?OutletStatus=1,1,1,1,1,0\n",
-    "?PowerStatus": b"?PowerStatus=0.4,48.0,120.0,0\n",
-    "?AutoReboot": b"?AutoReboot=1\n",
+    "?OutletStatus": b"?OutletStatus=1,1,1,1,1,1\n",
+    # current, power, voltage, safe-voltage flag. The flag reads 0 while the
+    # unit's own indicator is green, which is why IpWattBox inverts it.
+    "?PowerStatus": b"?PowerStatus=0.43,68.87,119.88,0\n",
+    "?AutoReboot": b"?AutoReboot=0\n",
     "?UPSConnection": b"?UPSConnection=0\n",
-    "?OutletPowerStatus=1": b"?OutletPowerStatus=1,17.9,0.1,120.0\n",
-    "?OutletPowerStatus=2": b"?OutletPowerStatus=2,21.4,0.2,120.0\n",
-    "?OutletPowerStatus=3": b"?OutletPowerStatus=3,0.0,0.0,120.0\n",
-    "?OutletPowerStatus=4": b"?OutletPowerStatus=4,4.2,0.0,120.0\n",
-    "?OutletPowerStatus=5": b"?OutletPowerStatus=5,4.5,0.0,120.0\n",
-    "?OutletPowerStatus=6": b"?OutletPowerStatus=6,0.0,0.0,120.0\n",
-    # PROVISIONAL: the exact reply a unit with no UPS gives to ?UPSStatus has
-    # not yet been captured from hardware -- `#Error` is the assumption being
-    # tested, and this fixture must be reconciled against captures/ before the
-    # upstream PR cites it. The driver is written so that either answer is
-    # handled: `update_requests` skips ?UPSStatus entirely unless
-    # ?UPSConnection reported a UPS, so this line only exercises the
-    # error-reply path of the driver itself.
-    "?UPSStatus": b"#Error\n",
+    # Captured from a unit with no UPS attached.
+    "?UPSStatus": b"?UPSStatus=0,0,Good,False,0,False,False\n",
+    # index, power, current, voltage
+    "?OutletPowerStatus=1": b"?OutletPowerStatus=1,12.62,0.09,119.88\n",
+    "?OutletPowerStatus=2": b"?OutletPowerStatus=2,21.40,0.18,119.88\n",
+    "?OutletPowerStatus=3": b"?OutletPowerStatus=3,4.20,0.04,119.88\n",
+    "?OutletPowerStatus=4": b"?OutletPowerStatus=4,29.86,0.25,119.88\n",
+    "?OutletPowerStatus=5": b"?OutletPowerStatus=5,0.00,0.00,119.88\n",
+    "?OutletPowerStatus=6": b"?OutletPowerStatus=6,0.79,0.00,119.88\n",
 }
 
-# Control messages answer with a bare OK. Included so the driver's non-"?"
-# path is covered; the tests never send these to real hardware.
+#: Not observed on WB-800-IPVM-6 / fw 2.10.0.0, but documented by the protocol
+#: and reported by other integrators. Used to pin the driver's error handling
+#: so an unsupported request degrades to a failed response rather than hanging.
+ERROR_REPLIES: dict[str, bytes] = {"?UPSStatus": b"#Error\n"}
+
+#: Control messages answer with a bare OK. Never sent to real hardware.
 CONTROL_OK: dict[str, bytes] = {
     "!OutletSet=1,ON,0": b"OK\n",
     "!OutletSet=1,OFF,0": b"OK\n",
 }
 
-LOGIN_BANNER = b"\r\nUsername: "
-LOGIN_PASSWORD_PROMPT = b"\r\nPassword: "
-LOGIN_SUCCESS = b"\r\nSuccessfully Logged In!\r\n"
+# Login sequence, verbatim from the capture. Note LF, not CRLF.
+LOGIN_BANNER = b"Please Login to Continue\n"
+LOGIN_USERNAME_PROMPT = b"Username: "
+LOGIN_PASSWORD_PROMPT = b"Password: "
+LOGIN_SUCCESS = b"Successfully Logged In!\n"

--- a/tests/test_async_driver.py
+++ b/tests/test_async_driver.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 
 from .conftest import FakeDevice
-from .fixtures import CONTROL_OK, OUTLET_NAMES, WB800_IPVM_6
+from .fixtures import CONTROL_OK, ERROR_REPLIES, OUTLET_NAMES, WB800_IPVM_6
 
 pytestmark = pytest.mark.asyncio
 
@@ -55,12 +55,16 @@ async def test_ssh_with_echo_returns_value(make_driver) -> None:
 
 
 async def test_error_reply_is_reported_not_hung(make_driver) -> None:
-    """``?UPSStatus`` on a unit with no UPS answers ``#Error``.
+    """An ``#Error`` reply must be flagged, not waited out.
 
-    The driver must return promptly and flag the failure rather than reading
-    until the timeout looking for a value that will never arrive.
+    WB-800-IPVM-6 on fw 2.10.0.0 was never observed returning ``#Error`` for
+    any read-only request, but the protocol documents it and other integrators
+    report it, so the path is pinned here with a synthetic reply.
     """
-    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=False), transport="asynctelnet")
+    driver = make_driver(
+        FakeDevice({**WB800_IPVM_6, **ERROR_REPLIES}, echo=False),
+        transport="asynctelnet",
+    )
 
     response = await driver._send_command("?UPSStatus")
 
@@ -95,4 +99,4 @@ async def test_outlet_power_status_indexed_reply(make_driver) -> None:
 
     response = await driver._send_command("?OutletPowerStatus=2")
 
-    assert response.result == "2,21.4,0.2,120.0"
+    assert response.result == "2,21.40,0.18,119.88"

--- a/tests/test_async_driver.py
+++ b/tests/test_async_driver.py
@@ -1,0 +1,98 @@
+"""Tests for WattBoxAsyncDriver against scripted WB-800-IPVM-6 behaviour.
+
+These cover the three ways the IP driver fails on 800-series hardware:
+
+* the device does not echo commands over raw telnet
+* replies may contain spaces, commas, braces and parentheses
+* some requests are answered with ``#Error`` rather than a value
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import FakeDevice
+from .fixtures import CONTROL_OK, OUTLET_NAMES, WB800_IPVM_6
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_telnet_no_echo_returns_value(make_driver) -> None:
+    """The core 800-series regression.
+
+    Over raw telnet these units send only the reply line. The driver used to
+    guard this case with ``self.transport not in ("telnet", "asynctelnet")``,
+    but ``self.transport`` is a transport *object*, never a string, so the
+    guard was always true and the driver issued a second read that blocked
+    until the operation timeout.
+    """
+    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=False), transport="asynctelnet")
+
+    response = await driver._send_command("?Model")
+
+    assert response.result == "WB-800-IPVM-6"
+    assert not response.failed
+
+
+async def test_telnet_outlet_name_with_spaces_is_not_truncated(make_driver) -> None:
+    """``?OutletName`` is polled on every update cycle."""
+    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=False), transport="asynctelnet")
+
+    response = await driver._send_command("?OutletName")
+
+    expected = ",".join("{" + n + "}" for n in OUTLET_NAMES)
+    assert response.result == expected
+    assert "Media Bridge 1 to 3" in response.result
+
+
+async def test_ssh_with_echo_returns_value(make_driver) -> None:
+    """The SSH path echoes; the reply must still be located correctly."""
+    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=True), transport="asyncssh")
+
+    response = await driver._send_command("?Firmware")
+
+    assert response.result == "2.10.0.0"
+
+
+async def test_error_reply_is_reported_not_hung(make_driver) -> None:
+    """``?UPSStatus`` on a unit with no UPS answers ``#Error``.
+
+    The driver must return promptly and flag the failure rather than reading
+    until the timeout looking for a value that will never arrive.
+    """
+    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=False), transport="asynctelnet")
+
+    response = await driver._send_command("?UPSStatus")
+
+    assert response.failed, "an #Error reply must mark the response failed"
+
+
+async def test_reply_split_across_packets(make_driver) -> None:
+    """A long reply arriving in several TCP segments must be reassembled."""
+    device = FakeDevice(WB800_IPVM_6, echo=False, chunk_size=8)
+    driver = make_driver(device, transport="asynctelnet")
+
+    response = await driver._send_command("?OutletName")
+
+    expected = ",".join("{" + n + "}" for n in OUTLET_NAMES)
+    assert response.result == expected
+
+
+async def test_control_message_returns_ok(make_driver) -> None:
+    """Control messages answer ``OK`` rather than ``?Key=value``."""
+    driver = make_driver(
+        FakeDevice({**WB800_IPVM_6, **CONTROL_OK}, echo=False), transport="asynctelnet"
+    )
+
+    response = await driver._send_command("!OutletSet=1,ON,0")
+
+    assert response.result == "OK"
+    assert not response.failed
+
+
+async def test_outlet_power_status_indexed_reply(make_driver) -> None:
+    driver = make_driver(FakeDevice(WB800_IPVM_6, echo=False), transport="asynctelnet")
+
+    response = await driver._send_command("?OutletPowerStatus=2")
+
+    assert response.result == "2,21.4,0.2,120.0"

--- a/tests/test_ip_wattbox.py
+++ b/tests/test_ip_wattbox.py
@@ -121,3 +121,32 @@ async def test_update_works_over_an_echoing_transport(wattbox) -> None:
 
     assert box.outlets[1].power_value == 12.62
     assert box.outlets[6].power_value == 0.79
+
+
+async def test_close_is_safe_when_never_connected(wattbox) -> None:
+    """Closing a WattBox that never opened a connection must not raise."""
+    box, _ = wattbox()
+
+    await box.async_close()  # no driver was ever created
+    box.close()
+
+
+async def test_close_releases_the_session(wattbox) -> None:
+    """The 800s cap concurrent sessions, so reloads must release theirs."""
+    box, _ = wattbox()
+    await box.async_get_initial()
+
+    closed = False
+
+    async def _close() -> None:
+        nonlocal closed
+        closed = True
+
+    box._async_driver.close = _close  # type: ignore[method-assign]
+    box._async_driver.transport = type(
+        "T", (), {"isalive": staticmethod(lambda: True)}
+    )()
+
+    await box.async_close()
+
+    assert closed, "async_close must close the underlying driver"

--- a/tests/test_ip_wattbox.py
+++ b/tests/test_ip_wattbox.py
@@ -1,0 +1,126 @@
+"""End-to-end tests for IpWattBox against a scripted WB-800-IPVM-6.
+
+Covers the two calls Home Assistant makes: ``async_get_initial`` at setup and
+``async_update`` on every poll.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pywattbox.ip_wattbox import IpWattBox
+
+from .conftest import FakeDevice
+from .fixtures import OUTLET_NAMES, WB800_IPVM_6
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def wattbox(make_driver):
+    """An IpWattBox whose async driver is wired to a scripted device."""
+
+    def _build(replies=None, *, echo: bool = False, chunk_size: int | None = None):
+        device = FakeDevice(replies or WB800_IPVM_6, echo=echo, chunk_size=chunk_size)
+        box = IpWattBox(host="192.0.2.1", user="admin", password="secret", port=23)
+        box._async_driver = make_driver(device, transport="asynctelnet")
+        return box, device
+
+    return _build
+
+
+async def test_initial_discovers_six_outlets(wattbox) -> None:
+    box, _ = wattbox()
+
+    await box.async_get_initial()
+
+    assert box.hardware_version == "WB-800-IPVM-6"
+    assert box.firmware_version == "2.10.0.0"
+    assert box.serial_number == "ST000000000000"
+    assert box.hostname == "WattBox"
+    assert box.number_outlets == 6
+    assert sorted(box.outlets) == [1, 2, 3, 4, 5, 6]
+    assert box.has_ups is False
+
+
+async def test_update_populates_names_status_and_power(wattbox) -> None:
+    box, _ = wattbox()
+    await box.async_get_initial()
+
+    await box.async_update()
+
+    # Names survive spaces and parentheses, and the braces are stripped.
+    assert [box.outlets[i].name for i in range(1, 7)] == list(OUTLET_NAMES)
+    assert [box.outlets[i].status for i in range(1, 7)] == [
+        True,
+        True,
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert box.current_value == 0.4
+    assert box.power_value == 48.0
+    assert box.voltage_value == 120.0
+    assert box.outlets[2].power_value == 21.4
+    assert box.outlets[2].voltage_value == 120.0
+
+
+async def test_update_skips_ups_request_without_a_ups(wattbox) -> None:
+    """A unit with no UPS must not be asked for UPS status.
+
+    Asking wastes a round trip on every poll and returns a reply that
+    ``parse_ups_status`` cannot handle -- which aborted the entire update.
+    """
+    box, device = wattbox()
+    await box.async_get_initial()
+    device.received.clear()
+
+    await box.async_update()
+
+    assert "?UPSStatus" not in device.received
+
+
+async def test_update_requests_ups_status_when_a_ups_is_present(wattbox) -> None:
+    replies = {
+        **WB800_IPVM_6,
+        "?UPSConnection": b"?UPSConnection=1\n",
+        "?UPSStatus": b"?UPSStatus=100,12,Good,False,45,False,False\n",
+    }
+    box, device = wattbox(replies)
+    await box.async_get_initial()
+    assert box.has_ups is True
+
+    await box.async_update()
+
+    assert "?UPSStatus" in device.received
+    assert box.battery_charge == 100
+    assert box.battery_health is True
+    assert box.power_lost is False
+    assert box.est_run_time == 45
+
+
+async def test_update_works_when_replies_are_fragmented(wattbox) -> None:
+    """Every reply arriving in 8-byte segments must still parse."""
+    box, _ = wattbox(chunk_size=8)
+    await box.async_get_initial()
+
+    await box.async_update()
+
+    assert box.outlets[1].name == "Media Bridge 1 to 3"
+    assert box.power_value == 48.0
+
+
+async def test_update_works_over_an_echoing_transport(wattbox) -> None:
+    """SSH echoes commands; the indexed per-outlet replies are the risk.
+
+    The echo of ``?OutletPowerStatus=1`` is itself a valid ``key=value`` line,
+    so a parser taking the first match reads the echo instead of the reading.
+    """
+    box, _ = wattbox(echo=True)
+    await box.async_get_initial()
+
+    await box.async_update()
+
+    assert box.outlets[1].power_value == 17.9
+    assert box.outlets[6].power_value == 0.0

--- a/tests/test_ip_wattbox.py
+++ b/tests/test_ip_wattbox.py
@@ -51,49 +51,46 @@ async def test_update_populates_names_status_and_power(wattbox) -> None:
 
     # Names survive spaces and parentheses, and the braces are stripped.
     assert [box.outlets[i].name for i in range(1, 7)] == list(OUTLET_NAMES)
-    assert [box.outlets[i].status for i in range(1, 7)] == [
-        True,
-        True,
-        True,
-        True,
-        True,
-        False,
-    ]
-    assert box.current_value == 0.4
-    assert box.power_value == 48.0
-    assert box.voltage_value == 120.0
-    assert box.outlets[2].power_value == 21.4
-    assert box.outlets[2].voltage_value == 120.0
+    assert all(box.outlets[i].status for i in range(1, 7))
+    assert box.current_value == 0.43
+    assert box.power_value == 68.87
+    assert box.voltage_value == 119.88
+    assert box.outlets[2].power_value == 21.40
+    assert box.outlets[2].voltage_value == 119.88
 
 
-async def test_update_skips_ups_request_without_a_ups(wattbox) -> None:
-    """A unit with no UPS must not be asked for UPS status.
+async def test_update_succeeds_on_a_unit_without_a_ups(wattbox) -> None:
+    """A unit with no UPS still answers ``?UPSStatus`` with a valid tuple.
 
-    Asking wastes a round trip on every poll and returns a reply that
-    ``parse_ups_status`` cannot handle -- which aborted the entire update.
+    Captured from hardware: ``?UPSConnection=0`` alongside
+    ``?UPSStatus=0,0,Good,False,0,False,False``. ``power_lost`` from that
+    reply backs a binary sensor, so the request must not be skipped just
+    because no UPS is attached.
     """
     box, device = wattbox()
     await box.async_get_initial()
+    assert box.has_ups is False
     device.received.clear()
 
     await box.async_update()
 
-    assert "?UPSStatus" not in device.received
+    assert "?UPSStatus" in device.received
+    assert box.power_lost is False
+    assert box.battery_charge == 0
 
 
-async def test_update_requests_ups_status_when_a_ups_is_present(wattbox) -> None:
+async def test_update_parses_ups_status_when_a_ups_is_present(wattbox) -> None:
     replies = {
         **WB800_IPVM_6,
         "?UPSConnection": b"?UPSConnection=1\n",
         "?UPSStatus": b"?UPSStatus=100,12,Good,False,45,False,False\n",
     }
-    box, device = wattbox(replies)
+    box, _ = wattbox(replies)
     await box.async_get_initial()
     assert box.has_ups is True
 
     await box.async_update()
 
-    assert "?UPSStatus" in device.received
     assert box.battery_charge == 100
     assert box.battery_health is True
     assert box.power_lost is False
@@ -108,7 +105,7 @@ async def test_update_works_when_replies_are_fragmented(wattbox) -> None:
     await box.async_update()
 
     assert box.outlets[1].name == "Media Bridge 1 to 3"
-    assert box.power_value == 48.0
+    assert box.power_value == 68.87
 
 
 async def test_update_works_over_an_echoing_transport(wattbox) -> None:
@@ -122,5 +119,5 @@ async def test_update_works_over_an_echoing_transport(wattbox) -> None:
 
     await box.async_update()
 
-    assert box.outlets[1].power_value == 17.9
-    assert box.outlets[6].power_value == 0.0
+    assert box.outlets[1].power_value == 12.62
+    assert box.outlets[6].power_value == 0.79

--- a/tests/test_prompt_pattern.py
+++ b/tests/test_prompt_pattern.py
@@ -1,0 +1,101 @@
+"""Tests for the channel prompt pattern.
+
+scrapli compiles ``PROMPTS`` with ``re.M | re.I`` and searches it against the
+read buffer to decide when a reply is complete. Two properties therefore
+matter, and neither held before this change:
+
+1. every alternative must be anchored, or the pattern matches mid-line
+2. a ``?Key=value`` reply must match in full, or the driver treats a truncated
+   prefix as a complete response
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pywattbox.driver import PROMPTS
+
+from .fixtures import WB800_IPVM_6
+
+PATTERN = re.compile(PROMPTS.encode(), flags=re.M | re.I)
+
+
+def _line(command: str) -> bytes:
+    """The reply line as the channel sees it: no trailing newline.
+
+    scrapli's ``_process_read_buf`` partitions the buffer on ``\\n`` before
+    searching, so the pattern is applied to the bare line.
+    """
+    return WB800_IPVM_6[command].rstrip(b"\r\n")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "?Model",
+        "?Firmware",
+        "?ServiceTag",
+        "?Hostname",
+        "?OutletCount",
+        "?OutletStatus",
+        "?PowerStatus",
+        "?AutoReboot",
+        "?UPSConnection",
+        "?OutletPowerStatus=1",
+    ],
+)
+def test_simple_replies_match_in_full(command: str) -> None:
+    line = _line(command)
+    match = PATTERN.search(line)
+    assert match is not None, f"no match for {line!r}"
+    assert match.group(0) == line, (
+        f"matched only {match.group(0)!r} of {line!r} -- a partial match makes "
+        "the channel return a truncated buffer"
+    )
+
+
+def test_outlet_name_with_spaces_matches_in_full() -> None:
+    """The regression that breaks every poll on a deployed unit.
+
+    ``?OutletName`` is in UPDATE_BASE_REQUESTS, and real outlet names contain
+    spaces. With ``\\S+`` the pattern matched only ``?OutletName={Apple``.
+    """
+    line = _line("?OutletName")
+    assert b" " in line, "fixture must exercise a value containing spaces"
+
+    match = PATTERN.search(line)
+    assert match is not None, f"no match for {line!r}"
+    assert match.group(0) == line, f"matched only {match.group(0)!r} of {line!r}"
+
+
+def test_error_reply_matches() -> None:
+    assert PATTERN.search(b"#Error") is not None
+
+
+def test_control_ok_matches() -> None:
+    assert PATTERN.search(b"OK") is not None
+
+
+def test_login_success_matches() -> None:
+    assert PATTERN.search(b"Successfully Logged In!") is not None
+
+
+def test_alternatives_are_anchored() -> None:
+    """A reply must not match part-way through a line.
+
+    Without a non-capturing group around the alternation, ``^`` binds only to
+    the first alternative and ``\\n$`` only to the last, leaving the
+    ``?Key=value`` branch free to match anywhere in the buffer.
+    """
+    assert PATTERN.search(b"trailing junk ?Model=X") is None
+    assert PATTERN.search(b"login banner text OK to proceed") is None
+
+
+def test_value_containing_a_question_mark_matches_in_full() -> None:
+    """Outlet names are user supplied and may contain anything printable."""
+    line = b"?OutletName={What? Yes},{Free}"
+    match = PATTERN.search(line)
+    assert match is not None
+    assert match.group(0) == line

--- a/tests/test_sync_driver.py
+++ b/tests/test_sync_driver.py
@@ -17,7 +17,7 @@ from scrapli.exceptions import ScrapliTimeout
 from pywattbox.driver.sync_driver import WattBoxDriver
 
 from .conftest import FakeDevice
-from .fixtures import OUTLET_NAMES, WB800_IPVM_6
+from .fixtures import ERROR_REPLIES, OUTLET_NAMES, WB800_IPVM_6
 
 
 class SyncFakeChannel:
@@ -80,7 +80,7 @@ def test_outlet_name_with_spaces_is_not_truncated(make_sync_driver) -> None:
 
 
 def test_error_reply_is_flagged(make_sync_driver) -> None:
-    driver = make_sync_driver(FakeDevice(WB800_IPVM_6, echo=False))
+    driver = make_sync_driver(FakeDevice({**WB800_IPVM_6, **ERROR_REPLIES}, echo=False))
 
     response = driver._send_command("?UPSStatus")
 

--- a/tests/test_sync_driver.py
+++ b/tests/test_sync_driver.py
@@ -1,0 +1,120 @@
+"""Tests for the synchronous WattBoxDriver.
+
+The sync driver carried exactly the same defects as the async one. It is not
+used by Home Assistant, which is presumably why it has been overlooked, but
+leaving the two implementations divergent is what allowed the bug to persist in
+one of them -- so the behaviour is pinned here too.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+from scrapli.exceptions import ScrapliTimeout
+
+from pywattbox.driver.sync_driver import WattBoxDriver
+
+from .conftest import FakeDevice
+from .fixtures import OUTLET_NAMES, WB800_IPVM_6
+
+
+class SyncFakeChannel:
+    """Synchronous counterpart to conftest.FakeChannel."""
+
+    def __init__(self, device: FakeDevice) -> None:
+        self.device = device
+        self._pending: list[bytes] = []
+        self._partial_command = ""
+
+    @contextmanager
+    def _channel_lock(self):
+        yield
+
+    def write(self, channel_input: str, **_kwargs: Any) -> None:
+        self._partial_command += channel_input
+
+    def send_return(self) -> None:
+        command, self._partial_command = self._partial_command, ""
+        self._pending.extend(self.device.feed(command))
+
+    def read(self) -> bytes:
+        if not self._pending:
+            raise ScrapliTimeout("no more data from device")
+        return self._pending.pop(0)
+
+
+@pytest.fixture
+def make_sync_driver():
+    def _make(device: FakeDevice) -> WattBoxDriver:
+        driver = WattBoxDriver(
+            host="192.0.2.1",
+            port=23,
+            auth_username="admin",
+            auth_password="secret",
+            transport="telnet",
+        )
+        driver.channel = SyncFakeChannel(device)  # type: ignore[assignment]
+        driver._open = lambda force=False: None  # type: ignore[assignment]
+        return driver
+
+    return _make
+
+
+def test_no_echo_returns_value(make_sync_driver) -> None:
+    driver = make_sync_driver(FakeDevice(WB800_IPVM_6, echo=False))
+
+    response = driver._send_command("?Model")
+
+    assert response.result == "WB-800-IPVM-6"
+    assert not response.failed
+
+
+def test_outlet_name_with_spaces_is_not_truncated(make_sync_driver) -> None:
+    driver = make_sync_driver(FakeDevice(WB800_IPVM_6, echo=False))
+
+    response = driver._send_command("?OutletName")
+
+    assert response.result == ",".join("{" + n + "}" for n in OUTLET_NAMES)
+
+
+def test_error_reply_is_flagged(make_sync_driver) -> None:
+    driver = make_sync_driver(FakeDevice(WB800_IPVM_6, echo=False))
+
+    response = driver._send_command("?UPSStatus")
+
+    assert response.failed
+
+
+def test_reply_split_across_packets(make_sync_driver) -> None:
+    driver = make_sync_driver(FakeDevice(WB800_IPVM_6, echo=False, chunk_size=8))
+
+    response = driver._send_command("?OutletName")
+
+    assert response.result == ",".join("{" + n + "}" for n in OUTLET_NAMES)
+
+
+def test_silent_device_raises_rather_than_returning_garbage(make_sync_driver) -> None:
+    """A request the device ignores must surface as a timeout.
+
+    Returning an empty result instead would push the failure downstream into
+    float()/int() parsing, where the cause is far harder to see.
+    """
+    driver = make_sync_driver(FakeDevice({}, echo=False))
+
+    with pytest.raises(ScrapliTimeout):
+        driver._send_command("?Model")
+
+
+def test_telnet_transport_bypasses_scrapli_auth() -> None:
+    """Telnet auth is handled in on_open, so transport auth must be bypassed."""
+    driver = WattBoxDriver(
+        host="192.0.2.1",
+        port=23,
+        auth_username="admin",
+        auth_password="secret",
+        transport="telnet",
+    )
+
+    assert driver.auth_bypass is True


### PR DESCRIPTION
## What

Makes the **WattBox 800 series** work over the IP driver, and adds the repository's first test suite.

Validated end to end against **six deployed units** — five WB-800-IPVM-6 and one WB-800-IPVM-12, all firmware **2.10.0.0**, over telnet — now running continuously in Home Assistant via `hass-wattbox`.

This addresses eseglem/hass-wattbox#55 and eseglem/hass-wattbox#56, and supersedes #27 by @seadillpicklerooster, whose diagnosis and wire captures this builds on. Their approach of reading the reply line directly, rather than relying on scrapli's prompt matching, is the right one and is kept here.

## The problems, in the order they bite

**1. Login never completes.** scrapli's in-channel telnet auth does not satisfy these units. Setup dies with:

```
ScrapliTimeout: timed out during in channel telnet authentication
```

Nothing below is reachable until this is fixed.

**2. The telnet guard in `_send_command` is dead code.** It reads:

```python
if self.transport not in ("telnet", "asynctelnet") and len(split_response) < 2:
```

`self.transport` is a transport *object*, so this is never equal to either string and the condition is always true. Every command therefore takes the "not enough lines, get more" branch and blocks on a second `_read_until_prompt()` until `timeout_ops`. `split_response[1]` is never reached, so the echo assumption is not what fails first. `on_open` in the sync driver already uses the correct `transport_name`.

**3. `PROMPTS` alternatives are ungrouped.** In `^(.*Successfully Logged In!)|(\?\w+=\S+)|(OK)|(#Error)\n$`, alternation binds looser than the anchors, so `^` applies only to the first branch and `\n$` only to the last. The `?Key=value` branch matches mid-line, and `#Error` can **never** match at all — scrapli's `_process_read_buf` partitions the buffer on `\n` before searching, so a pattern requiring a newline is unreachable.

**4. `\S+` cannot match values containing spaces.** Outlet names are user supplied. On a real unit `?OutletName={Hue Sync Power 1 to 3},{Apple TV 06 Office Wall},...` matched only as far as `?OutletName={Hue`. `?OutletName` is in `UPDATE_BASE_REQUESTS`, so this fires on every poll.

## The fix

* **Telnet auth** — `auth_bypass=True` at the transport, with the `Username:`/`Password:` handshake performed in `on_open`, gated on `transport_name in ("telnet", "asynctelnet")`. The SSH path is left on its original code path.
* **`_send_command`** — reads until a *complete* reply line for the command arrives, matched on the key rather than a line index. Requiring the terminating newline is what makes incremental reads safe: without it a reply still arriving in pieces (`?OutletName={Hue Sync`) looks like a finished line and is accepted truncated. An echoed line is skipped explicitly, which matters for `?OutletPowerStatus=N` whose echo is itself a syntactically valid `key=value` line.
* **`PROMPTS`** — alternatives wrapped in a non-capturing group so `^`/`$` anchor all of them, and values may contain anything but a line break.
* **Both drivers.** The sync driver carried identical defects. Parsing is now shared in `driver/__init__.py` rather than duplicated, since that duplication is why the bug survived in one copy.
* **`close()` / `async_close()`** — there was no way to release a connection. These units cap concurrent sessions, so a consumer that re-creates its WattBox leaked one session per reload.

## Tests

The repository had none. Adds 37, using a fake channel that reuses scrapli's *real* prompt-matching helpers (`_get_prompt_pattern`, `_process_read_buf`) — a hand-rolled approximation would hide exactly these bugs.

Covers: no-echo and echoing transports, values containing spaces, replies fragmented across packets, `#Error` replies, UPS and non-UPS units, indexed `?OutletPowerStatus` replies, a silent device, and a full `async_get_initial()` → `async_update()` cycle for a 6-outlet unit.

`pytest` green, `ruff` clean, `mypy` clean under the existing strict settings.

## Two things the captures corrected

Both contradict claims circulating in the linked issues, so they are worth stating:

* **A unit with no UPS does not answer `?UPSStatus` with `#Error`.** It returns a well-formed zeroed tuple — `?UPSConnection=0` and `?UPSStatus=0,0,Good,False,0,False,False` coexist happily. `power_lost` comes from that reply and backs a binary sensor, so the request must not be skipped on non-UPS units. An earlier revision of this branch did skip it; that was wrong and is reverted.
* **No request in the read-only set ever produced `#Error`** on this firmware. The error path is still handled because the protocol documents it, but its fixture is marked explicitly synthetic rather than presented as captured.

## Notes

* Fixture outlet names and service tag are substitutes preserving the properties under test (embedded spaces, digits, repeated values); response shapes, field counts, numeric formats and framing are verbatim.
* **SSH is unverified.** On these units port 22 runs `dropbear_2025.88` and is used by OvrC; it rejects the device's own credentials for both password and keyboard-interactive auth. The SSH path is unchanged and still exercised by tests, but I could not confirm it against hardware. A second pair of eyes there would be welcome.
