### PR TITLE
Make the mypy hook runnable on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,16 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.2
     hooks:
       - id: mypy
         name: Run Mypy
         files: ^pywattbox/
-        types: [python]
-        language: system
-        entry: mypy --config-file=pyproject.toml pywattbox/
+        args: ["--config-file=pyproject.toml", "pywattbox/"]
         pass_filenames: false
+        additional_dependencies:
+          - beautifulsoup4
+          - httpx
+          - scrapli
+          - types-beautifulsoup4


### PR DESCRIPTION
Unsolicited, and separate from #28 on purpose — it is a CI fix, not a code change, and it is useful whether or not that PR goes anywhere.

## The problem

The `mypy` hook is `language: system`, so pre-commit expects to find a `mypy` executable already on `PATH`. That works locally inside the project venv. pre-commit.ci builds an isolated environment per hook and has no project venv, so every run there ends with:

```
Run Mypy.................................................................Failed
- hook id: mypy
- exit code: 1
Executable `mypy` not found
```

The other ten hooks pass. This is not specific to any branch — [#27](https://github.com/eseglem/pywattbox/pull/27) and [#28](https://github.com/eseglem/pywattbox/pull/28) fail identically, and so would anything else opened against this repo. As it stands no PR here can show a green check.

## The change

Point the hook at `mirrors-mypy` so pre-commit builds the environment itself. `additional_dependencies` carries the three libraries the package imports (`bs4`, `httpx`, `scrapli`), which mypy needs to resolve because `[tool.mypy]` does not set `ignore_missing_imports`. `types-beautifulsoup4` matches the dev dependency you already declare.

`rev: v1.20.2` stays inside the `mypy = "^1.9"` constraint in `pyproject.toml`, so this does not change which mypy major version your code is checked against. It also means the `autoupdate_schedule: monthly` you already have will keep it current — something `language: system` could never do.

Nothing about the mypy invocation changes: same config file, same target, same `pass_filenames: false`, same `Run Mypy` label in the output.

## Verified

On this commit, with no `mypy` on `PATH` at all, so the isolated environment is genuinely doing the work:

```
check for added large files..............................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
pyupgrade................................................................Passed
ruff.....................................................................Passed
ruff-format..............................................................Passed
Run Mypy.................................................................Passed
```

That is against `master`'s code, not mine — this branch contains nothing but the config change.

Happy to drop it if you would rather keep the system hook and just live with the red check.
