### PR TITLE
Fix WattBox 800 series support over telnet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywattbox"
-version = "0.9.1"
+version = "0.9.2"
 description = "A python wrapper for WattBox APIs."
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pywattbox"
-version = "0.9.0"
+version = "0.9.1"
 description = "A python wrapper for WattBox APIs."
 license = "MIT"
 readme = "README.md"

--- a/pywattbox/driver/__init__.py
+++ b/pywattbox/driver/__init__.py
@@ -17,5 +17,10 @@ PROMPTS: Final[str] = (
     r"|(?:\?\w+=[^\n]*)"  # Response to `?` request message
     r"|(?:OK)"  # Response to `!` control message
     r"|(?:#Error)"  # Error Message
-    r")\n"  # All responses are newline terminated
+    r")\n?$"  # Optional trailing newline, anchored to end of line
 )
+# The trailing newline must stay OPTIONAL: scrapli's `_process_read_buf`
+# partitions the read buffer on the first newline and hands the regex only the
+# remainder, so by the time a single-line response is searched its terminating
+# newline has already been stripped. Requiring `\n` here makes the prompt never
+# match and every read blocks until the transport times out.

--- a/pywattbox/driver/__init__.py
+++ b/pywattbox/driver/__init__.py
@@ -1,10 +1,21 @@
 from typing import Final
 
+# Every message the WattBox Integration Protocol sends is LF-terminated, so each
+# alternative below requires a trailing newline. The previous pattern relied on
+# `^` / `\n$` written outside the alternation, which (because `|` has the lowest
+# precedence) anchored only the first and last branches -- the middle branches
+# could match mid-stream and cause `_read_until_prompt` to return a truncated
+# buffer.
+#
+# The value part is `[^\n]*` rather than `\S+` because values legitimately
+# contain spaces, e.g. a WB-800VPS-IPVM-12 replies:
+#   ?OutletName={Synology},{VMWare},{USB Drive 1},{Outlet 4},...
+# `\S+` stops at the first space, so the prompt never matched the full line.
 PROMPTS: Final[str] = (
-    r"^"  # Start of the string
-    r"(.*Successfully Logged In!)|"  # After Login
-    r"(\?\w+=\S+)|"  # Response to `?` request message
-    r"(OK)|"  # Response to `!` control message
-    r"(#Error)"  # Error Message
-    r"\n$"  # Newline / End of String
+    r"(?:"
+    r"(?:.*Successfully Logged In!)"  # After Login
+    r"|(?:\?\w+=[^\n]*)"  # Response to `?` request message
+    r"|(?:OK)"  # Response to `!` control message
+    r"|(?:#Error)"  # Error Message
+    r")\n"  # All responses are newline terminated
 )

--- a/pywattbox/driver/async_driver.py
+++ b/pywattbox/driver/async_driver.py
@@ -14,6 +14,9 @@ from . import PROMPTS
 
 logger = logging.getLogger("pywattbox.async_driver")
 
+# Transports that do not echo the command back before the response.
+NON_ECHOING_TRANSPORTS = ("telnet", "asynctelnet")
+
 
 async def on_open(driver: WattBoxAsyncDriver) -> None:
     # if driver.transport_name not in ("telnet", "asynctelnet"):
@@ -116,6 +119,11 @@ class WattBoxAsyncDriver(AsyncDriver):
 
         logger.debug("Sending Command: %s", command)
 
+        # `self.transport` is the transport *instance*; comparing it against
+        # transport name strings is never equal, so these checks used to be
+        # unconditionally true. `self.transport_name` is the string.
+        expects_echo = self.transport_name not in NON_ECHOING_TRANSPORTS
+
         # Normally handled in the channel `send_input`, but WattBox is special and doesn't work
         # with that function. Pulled it all into the Driver for simplicity.
         async with self.channel._channel_lock():
@@ -126,20 +134,14 @@ class WattBoxAsyncDriver(AsyncDriver):
             logger.debug("raw_response: %s", raw_response)
             split_response = raw_response.strip().splitlines()
             logger.debug("split_response: %s", split_response)
-            if (
-                self.transport not in ("telnet", "asynctelnet")
-                and len(split_response) < 2
-            ):
+            if expects_echo and len(split_response) < 2:
                 logger.debug("Not enough lines: %s. Getting more", len(split_response))
                 raw_response += await self.channel._read_until_prompt()
                 logger.debug("raw_response: %s", raw_response)
                 split_response = raw_response.strip().splitlines()
                 logger.debug("split_response: %s", split_response)
 
-        if (
-            self.transport not in ("telnet", "asynctelnet")
-            and split_response[0] != command.encode()
-        ):
+        if expects_echo and split_response[0] != command.encode():
             logger.error("Doesn't match command: %s - %s", command, split_response[0])
 
         if command.startswith("?"):
@@ -149,7 +151,10 @@ class WattBoxAsyncDriver(AsyncDriver):
                     command,
                     split_response[-1],
                 )
-            processed_response = split_response[1].split(b"=")[-1]
+            # Use the last line rather than index 1. Devices that echo put the
+            # reply there too, but non-echoing units (WB-800 series over telnet)
+            # return a single line and index 1 raised IndexError on every command.
+            processed_response = split_response[-1].split(b"=")[-1]
         else:
             processed_response = split_response[-1]
 

--- a/pywattbox/driver/async_driver.py
+++ b/pywattbox/driver/async_driver.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
 from collections.abc import Callable
 from io import BytesIO
 from typing import Any
 
 from scrapli.decorators import timeout_modifier
 from scrapli.driver import AsyncDriver
-from scrapli.exceptions import ScrapliConnectionNotOpened
+from scrapli.exceptions import ScrapliAuthenticationFailed, ScrapliConnectionNotOpened
 from scrapli.response import Response
 
 from . import PROMPTS
@@ -17,10 +19,60 @@ logger = logging.getLogger("pywattbox.async_driver")
 # Transports that do not echo the command back before the response.
 NON_ECHOING_TRANSPORTS = ("telnet", "asynctelnet")
 
+# Login prompts emitted by the WattBox Integration Protocol. Neither is
+# newline-terminated, so they only ever appear at the very end of the buffer.
+LOGIN_PROMPT = re.compile(rb"username:\s*$", flags=re.I | re.M)
+PASSWORD_PROMPT = re.compile(rb"password:\s*$", flags=re.I | re.M)
+
+
+async def _read_until(channel: Any, pattern: re.Pattern[bytes], timeout: float) -> bytes:
+    """Read from the channel until `pattern` matches, without writing anything."""
+
+    async def _reader() -> bytes:
+        buf = b""
+        while True:
+            buf += await channel.read()
+            if pattern.search(buf):
+                return buf
+
+    try:
+        return await asyncio.wait_for(_reader(), timeout=timeout)
+    except asyncio.TimeoutError as err:
+        raise ScrapliAuthenticationFailed(
+            f"timed out waiting for {pattern.pattern!r} during WattBox login"
+        ) from err
+
 
 async def on_open(driver: WattBoxAsyncDriver) -> None:
-    # if driver.transport_name not in ("telnet", "asynctelnet"):
     logger.debug("On Open")
+
+    if driver.transport_name in NON_ECHOING_TRANSPORTS:
+        # We drive the login ourselves (see `auth_bypass` in __init__).
+        #
+        # scrapli's in-channel telnet auth periodically writes an unsolicited
+        # return character to "kick" devices that need prompting. The WattBox
+        # treats *every* newline as a submitted field, so a kick sent before the
+        # banner arrives is consumed as an empty username: the device then jumps
+        # straight to the password prompt and the real username is submitted as
+        # the password, yielding `Invalid Login`. The banner takes ~1.0s on a
+        # WB-800VPS-IPVM-12 while scrapli's default kick interval is
+        # timeout_ops/10 = 0.5s, so this happened on every connection.
+        #
+        # Reading without writing keeps the device's field-by-field state
+        # machine in step, and does not depend on response timing.
+        timeout = getattr(driver, "timeout_ops", 30.0) or 30.0
+
+        logger.debug("Waiting for username prompt")
+        await _read_until(driver.channel, LOGIN_PROMPT, timeout)
+        driver.channel.write(channel_input=driver.auth_username)
+        driver.channel.send_return()
+
+        logger.debug("Waiting for password prompt")
+        await _read_until(driver.channel, PASSWORD_PROMPT, timeout)
+        driver.channel.write(channel_input=driver.auth_password, redacted=True)
+        driver.channel.send_return()
+
+    # Consumes the post-login banner (`Successfully Logged In!`).
     await driver.channel._read_until_prompt()
 
 
@@ -60,6 +112,11 @@ class WattBoxAsyncDriver(AsyncDriver):
         channel_lock: bool = True,
         logging_uid: str = "",
     ) -> None:
+        if transport in NON_ECHOING_TRANSPORTS:
+            # Skip scrapli's in-channel telnet auth; `on_open` performs the
+            # login instead. See the comment there for why.
+            auth_bypass = True
+
         super().__init__(
             host=host,
             port=port,

--- a/pywattbox/driver/async_driver.py
+++ b/pywattbox/driver/async_driver.py
@@ -25,7 +25,9 @@ LOGIN_PROMPT = re.compile(rb"username:\s*$", flags=re.I | re.M)
 PASSWORD_PROMPT = re.compile(rb"password:\s*$", flags=re.I | re.M)
 
 
-async def _read_until(channel: Any, pattern: re.Pattern[bytes], timeout: float) -> bytes:
+async def _read_until(
+    channel: Any, pattern: re.Pattern[bytes], timeout: float
+) -> bytes:
     """Read from the channel until `pattern` matches, without writing anything."""
 
     async def _reader() -> bytes:


### PR DESCRIPTION
Three bugs prevented the IP (telnet) path from working against WattBox 800 series hardware. All three are fixed here and verified end-to-end against a real **WB-800VPS-IPVM-12, firmware 2.8.0.0**, on port 23.

This also resolves the driver half of eseglem/hass-wattbox#55, and is relevant to eseglem/hass-wattbox#56 (see the note at the bottom).

## Bug 1 — prompt pattern truncated values containing spaces

`PROMPTS` matched values with `\S+`, which stops at the first space. Real response from the device:

```
?OutletName={Synology},{VMWare},{USB Drive 1},{Outlet 4},{Outlet 5},{USB Drive 2},...
```

Tested against the old pattern, it matched **36 of 158 characters**, cutting off inside `{USB Drive 1}`.

There was a second, subtler problem in the same pattern: `|` has the lowest precedence in a regex, so the `^` and `\n$` written at the ends of the concatenated string bound only to the *first* and *last* alternatives. The `?`-response branch was effectively unanchored.

The value part is now `[^\n]*`, with an optional trailing newline anchored to end-of-line.

**Important subtlety, in case it looks over-cautious:** the trailing newline must stay *optional*. `Channel._process_read_buf` partitions the read buffer on the first newline and searches only the remainder, so a single-line response has already had its terminator stripped by the time the pattern is applied. An earlier iteration of this patch required `\n` and every read blocked until the transport timed out.

## Bug 2 — response parsing assumed the device echoes the command

```python
processed_response = split_response[1].split(b"=")[-1]
```

Index `1` assumes `split_response[0]` holds the echoed command. The 800 series does not echo over telnet — all thirteen commands in my capture returned a single line — so this raised `IndexError` on **every** command.

Changed to `split_response[-1]`, which is correct whether or not the device echoes, and is consistent with the validation check immediately above it that already used `[-1]`.

## Bug 3 — transport checks compared an object against strings

```python
if self.transport not in ("telnet", "asynctelnet") and len(split_response) < 2:
```

`self.transport` is the transport *instance*, so this comparison is never equal and the condition was unconditionally true. On telnet that triggered a second `_read_until_prompt()` which blocks until timeout, plus a spurious echo-mismatch error. `self.transport_name` is the string form — as the commented-out line in `on_open` already hints.

## Bug 4 — scrapli's in-channel telnet auth desynchronizes the login

This was the one that actually blocked connection. `Channel.channel_authenticate_telnet` periodically writes an unsolicited return character to "kick" devices that need prompting, at `timeout_ops / 10` (0.5s with this driver's defaults). The WattBox banner takes **~1.01s** to arrive (measured over three connections), so the kick always landed first.

Because the device treats *every* newline as a submitted field, that kick was consumed as an empty username. The device advanced to the password prompt, the real username was then submitted as the password, and login failed. Captured exchange:

```
write: '\n'                                              <- unsolicited kick
read:  b'Please Login to Continue\nUsername: Password: '  <- both prompts, kick eaten as username
write: 'admin'                                           <- submitted as the PASSWORD
read:  b'Invalid Login\n'
```

surfacing as `ScrapliTimeout: timed out during in channel telnet authentication`.

The driver now sets `auth_bypass=True` for telnet transports and performs the login in `on_open`, reading each prompt without writing anything unsolicited. This is timing-independent rather than merely retuned — raising `timeout_ops` would only make the race less likely.

Note the prompts are not newline-terminated (`Username: `, `Password: `) and the device speaks raw TCP with no IAC negotiation, which is why the generic telnet auth path is a poor fit here.

## Verification

Against a live WB-800VPS-IPVM-12:

```
CONNECTED
  model    : WB-800VPS-IPVM-12
  firmware : 2.8.0.0
  hostname : SunWattBox
  outlets  : 12
  power    : 355.97 W    current: 2.69 A    voltage: 115.75 V
  has_ups  : True        battery: 100% charge, 25% load, 30 min runtime
  --- per-outlet ---
   1. Synology          status=True   power=85.64 W   current=0.65 A
   3. USB Drive 1       status=True   power=6.78 W    current=0.01 A
   6. USB Drive 2       status=True   power=8.17 W    current=0.03 A
   7. Outlet 7          status=True   power=136.47 W  current=1.09 A
   8. Outlet 8          status=True   power=116.05 W  current=0.91 A
  12. Creality Printer  status=False  power=0.0 W     current=0.0 A
```

Outlet names containing spaces parse correctly, and `?OutletPowerStatus` per-outlet metering works.

The HTTP path is untouched — a WB-700-IPV-12 on the same network continues to work unchanged through `http_wattbox.py`.

## Notes

- **The `pyproject.toml` version bump is incidental.** I needed installers to see a new version while testing from a branch tarball; drop it if you'd rather manage versioning yourself.
- `sync_driver.py` likely needs the same treatment as bugs 2 and 3. I have not touched it because I could not test the sync path, and I would rather not submit unverified changes.
- SSH (port 22) is a separate matter: the device offers `publickey,password` via dropbear 2020.81, but rejects the same credentials that work over telnet, so it appears to gate SSH access separately. Not addressed here.
- Regarding eseglem/hass-wattbox#56: on this firmware the 800 returns **404** for `wattbox_info.xml` even with correct credentials. It serves no machine-readable HTTP API at all — only `/main`, whose `main.js` contains no AJAX. It also requires **Digest** auth (`WWW-Authenticate: Digest realm="OvrC Wattbox"`, `Server: OvrC Embedded Server`) while `http_wattbox.py` sends Basic via an httpx tuple, so that reporter hit auth first and would have hit 404 immediately after. HTTP looks like a dead end for 800-series; telnet is the path.
